### PR TITLE
Update instructions: red LED may stay on

### DIFF
--- a/jetson-tx1.coffee
+++ b/jetson-tx1.coffee
@@ -4,7 +4,7 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 BOARD_POWERON = 'Press and hold for 1 second the POWER push button.'
 
 postProvisioningInstructions = [
-	instructions.BOARD_SHUTDOWN
+	instructions.BOARD_SHUTDOWN + ' The red LED next to the fan power connector may stay on.'
 	instructions.REMOVE_INSTALL_MEDIA
 	instructions.BOARD_REPOWER
 ]


### PR DESCRIPTION
Improvement suggested in this forum thread: https://forums.balena.io/t/improvements-to-jetson-tx1-add-new-device-instructions/4899

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_gf9v)