### PR TITLE
u-boot: Enable CONFIG_CMD_SETEXPR for jetson-tx1

### DIFF
--- a/layers/meta-resin-jetson/recipes-bsp/u-boot/u-boot-tegra/0002-jetson-tx1-Enable-CONFIG_CMD_SETEXPR.patch
+++ b/layers/meta-resin-jetson/recipes-bsp/u-boot/u-boot-tegra/0002-jetson-tx1-Enable-CONFIG_CMD_SETEXPR.patch
@@ -1,0 +1,30 @@
+From 2f4af002afe7dabd259de5800f0008d53d17fab7 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 29 Jan 2019 08:58:18 +0100
+Subject: [PATCH] jetson-tx1: Enable CONFIG_CMD_SETEXPR
+
+This is necessary for integration with the
+BalenaOS v2.30 release
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ configs/p2371-2180_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/p2371-2180_defconfig b/configs/p2371-2180_defconfig
+index 4e365b5..cc1f3ab 100644
+--- a/configs/p2371-2180_defconfig
++++ b/configs/p2371-2180_defconfig
+@@ -18,7 +18,7 @@ CONFIG_CMD_DFU=y
+ CONFIG_CMD_USB_MASS_STORAGE=y
+ # CONFIG_CMD_FPGA is not set
+ CONFIG_CMD_GPIO=y
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
+ CONFIG_CMD_DHCP=y
+ # CONFIG_CMD_NFS is not set
+ CONFIG_CMD_MII=y
+-- 
+2.7.4
+

--- a/layers/meta-resin-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-resin-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -7,3 +7,4 @@ RESIN_DEFAULT_ROOT_PART = "0xb"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " file://0001-Integrate-resin-u-boot.patch"
+SRC_URI_append_jetson-tx1 = " file://0002-jetson-tx1-Enable-CONFIG_CMD_SETEXPR.patch"


### PR DESCRIPTION
Enabled CMD_SETEXPR config in u-boot for jetson-tx1

Changelog-entry: Enable CONFIG_CMD_SETEXPR for jetson-tx1 u-boot
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Fixes https://github.com/balena-os/balena-jetson-tx1/issues/14